### PR TITLE
fix: format reminder update call

### DIFF
--- a/telegram-reminder-bot/bot.py
+++ b/telegram-reminder-bot/bot.py
@@ -147,7 +147,14 @@ async def edit_reminder(message: types.Message):
         print(e)
         await message.answer("error")
         return
-    db.update(rid, parsed["category"], parsed["content"], parsed["time"], parsed.get("timezone", tz), parsed.get("repeat", "none"))
+    db.update(
+        rid,
+        parsed["category"],
+        parsed["content"],
+        parsed["time"],
+        parsed.get("timezone", tz),
+        parsed.get("repeat", "none"),
+    )
     parsed["id"] = rid
     parsed.setdefault("timezone", tz)
     parsed.setdefault("repeat", "none")


### PR DESCRIPTION
## Summary
- format database update call in edit_reminder

## Testing
- `python -m py_compile telegram-reminder-bot/*.py`


------
https://chatgpt.com/codex/tasks/task_b_68b3c6888e7083319eeefcb2761a0e5b